### PR TITLE
chore: add pyproject.toml config (isort/black/mypy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["yourpkg"]
+src_paths = ["src", "tests"]
+
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.11"
+pretty = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = false
+ignore_missing_imports = true
+mypy_path = ["src"]


### PR DESCRIPTION
Adds pyproject.toml to centralize isort/black/mypy settings so local and CI tooling stay consistent.